### PR TITLE
Readd empty constructors to all features

### DIFF
--- a/AreaShop/src/main/java/me/wiefferink/areashop/features/FriendsFeature.java
+++ b/AreaShop/src/main/java/me/wiefferink/areashop/features/FriendsFeature.java
@@ -19,6 +19,8 @@ public class FriendsFeature extends RegionFeature {
 		setRegion(region);
 	}
 
+	public FriendsFeature() {}
+
 	/**
 	 * Add a friend to the region.
 	 * @param player The UUID of the player to add

--- a/AreaShop/src/main/java/me/wiefferink/areashop/features/signs/SignsFeature.java
+++ b/AreaShop/src/main/java/me/wiefferink/areashop/features/signs/SignsFeature.java
@@ -36,7 +36,9 @@ public class SignsFeature extends RegionFeature {
 	private static final Map<String, RegionSign> allSigns = Collections.synchronizedMap(new HashMap<>());
 	private static final Map<String, List<RegionSign>> signsByChunk = Collections.synchronizedMap(new HashMap<>());
 
-	private final Map<String, RegionSign> signs;
+	private Map<String, RegionSign> signs;
+
+	public SignsFeature() {}
 
 	/**
 	 * Constructor.

--- a/AreaShop/src/main/java/me/wiefferink/areashop/managers/FeatureManager.java
+++ b/AreaShop/src/main/java/me/wiefferink/areashop/managers/FeatureManager.java
@@ -49,6 +49,7 @@ public class FeatureManager extends Manager {
 				AreaShop.error("Failed to instantiate global feature:", clazz, e);
 			} catch(NoSuchMethodException e) {
 				// Feature does not have a global part
+				AreaShop.error("Feature ", clazz.getName(), " is missing an empty constructor.");
 			}
 		}
 


### PR DESCRIPTION
because else the FeatureManager is unable to instantiate these classes which results in a [NoSuchMethodException beeing catched without any error](https://github.com/TreasureIslandMC/AreaShop/blob/master/AreaShop/src/main/java/me/wiefferink/areashop/managers/FeatureManager.java#L50-L52).

I had problems with the AreaShop signs before, they work fine again after this small change.